### PR TITLE
Source Build Targets from Directory Name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,11 @@
 
 
 OBSV_TAG := $(shell git submodule status|cut -d '(' -f 2|cut -d ')' -f 1)
-# OBSV_TAG := $(shell git submodule status)
-DDB_TAG := $(shell basename `pwd`|sed 's/^duck-python-udf-ddb\(v[0-9.]*\)-.*/\1/')
+DDB_TAG := $(shell basename `pwd`|sed 's/^duckdb-python-udf-\(.*\)-[a-z]*/\1/')
 ifeq (${DDB_TAG}, "")
 	DDB_TAG=${OBSV_TAG}
 endif
-BUILD_FLAVOR=$(shell basename `pwd`|sed 's/^duck-python-udf-ddbv[0-9.]*-\(.*\)/\1/')
+BUILD_FLAVOR=$(shell basename `pwd`|sed 's/^duckdb-python-udf-.*-\([a-z]*\)/\1/')
 ifeq (${BUILD_FLAVOR}, "")
 	BUILD_FLAVOR=release
 endif

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ submod_check: duckdb
 		echo "Found submodule at ${OBSV_TAG} as expected"; \
 	fi
 
+submod: pull
+	cd duckdb && git co ${DDB_TAG}
+
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJ_DIR := $(dir $(MKFILE_PATH))
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean format debug release duckdb_debug duckdb_release pull update
 
 
-OBSV_TAG := $(shell git submodule status|cut -d '(' -f 2|cut -d ')' -f 1)
+OBSV_TAG := $(shell cd duckdb && (git symbolic-ref --short HEAD 2>/dev/null || git describe --exact-match --tags HEAD))
 DDB_TAG := $(shell basename `pwd`|sed 's/^duckdb-python-udf-\(.*\)-[a-z]*/\1/')
 ifeq (${DDB_TAG}, "")
 	DDB_TAG=${OBSV_TAG}


### PR DESCRIPTION
Update makefile to pull in a desired duckdb version + build flavor from the name of the checkout directory. This lets us have a couple of different checkouts limiting full rebuilds (hopefully).