### PR TITLE
Separate Builds for Each Supported Python Version, Take 2!

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -31,15 +31,23 @@ jobs:
           #   container: 'quay.io/pypa/manylinux2014_x86_64'
     env:
       GEN: ninja
-      DEFAULT_DDB_VERSION: '0.8.0'
-      # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
-      # repo is pinned to". That doesn't help when we're building an artifact name that includes
-      # the version of duckdb we've pinned against. So we create a separate variable here that will
-      # contain the actual version number. Note it requires the pinned version in the repo to match
-      # the above version number. Sorry future me who will def forget to do so.
-      DDB_VERSION: ${{ if '<submodule_version>' == matrix.duckdb_version env.DEFAULT_DDB_VERSION  else  matrix.duckdb_version endif }}
+    steps:      
+    # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
+    # repo is pinned to". That doesn't help when we're building an artifact name that includes
+    # the version of duckdb we've pinned against. So we create a separate variable here that will
+    # contain the actual version number.
+    - name: Extract + Export DuckDB Pinned Version if in Use
+      if: '<submodule_version>' == matrix.duckdb_version
+      run: |
+        export DUCKDB_VERSION=`git tag --points-at HEAD`
+        export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+        echo "DDB_VERSION=${DUCKDB_VERSION}" >> $GITHUB_ENV
       
-    steps:
+    - name: Export DuckDB if Ignoring Pinned Version
+      if: '<submodule_version>' != matrix.duckdb_version
+      run: |
+        echo "DDB_VERSION=${{matrix.duckdb_version}}" >> $GITHUB_ENV
+
     - name: Install required ubuntu packages
       if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
       run: |

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -31,163 +31,170 @@ jobs:
           #   container: 'quay.io/pypa/manylinux2014_x86_64'
     env:
       GEN: ninja
-    steps:      
-      # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
-      # repo is pinned to". That doesn't help when we're building an artifact name that includes
-      # the version of duckdb we've pinned against. So we create a separate variable here that will
-      # contain the actual version number.
-      - name: Extract + Export DuckDB Pinned Version if in Use
-        if: '<submodule_version>' == matrix.duckdb_version
-        run: |
-          export DUCKDB_VERSION=`git tag --points-at HEAD`
-          export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
-          echo "DDB_VERSION=${DUCKDB_VERSION}" >> $GITHUB_ENV
+    steps:
+    - name: Extract + Export DuckDB Pinned Version if in Use
+      if: '<submodule_version>' == matrix.duckdb_version
+      run: |
+        export DUCKDB_VERSION=`git tag --points-at HEAD`
+        export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+        echo "DDB_VERSION=${DUCKDB_VERSION}" >> $GITHUB_ENV
       
-      - name: Export DuckDB if Ignoring Pinned Version
-        if: '<submodule_version>' != matrix.duckdb_version
-        run: |
-          echo "DDB_VERSION=${{matrix.duckdb_version}}" >> $GITHUB_ENV
+    - name: Export DuckDB if Ignoring Pinned Version
+      if: '<submodule_version>' != matrix.duckdb_version
+      run: |
+        echo "DDB_VERSION=${{matrix.duckdb_version}}" >> $GITHUB_ENV
 
-      - name: Install required ubuntu packages
-        if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
-        run: |
-          apt-get update -y -qq
-          apt-get install -y -qq software-properties-common
-          add-apt-repository ppa:deadsnakes/ppa
-          apt-get update -y -qq
-          apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client git clang-format libasan6 ccache docker.io
-          git config --global --add safe.directory '*'
+    - name: Install required ubuntu packages
+      if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
+      run: |
+        apt-get update -y -qq
+        apt-get install -y -qq software-properties-common
+        add-apt-repository ppa:deadsnakes/ppa
+        apt-get update -y -qq
+        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client git clang-format libasan6 ccache docker.io
+        git config --global --add safe.directory '*'
 
-      - name: Setup Python ${{ matrix.python_version }}
-        run: |
-          apt-get install -y -qq python${{ matrix.python_version }}-dev
+    - name: Setup Python ${{ matrix.python_version }}
+      run: |
+        apt-get install -y -qq python${{ matrix.python_version }}-dev
   
-      # - name: Set up Python ${{ matrix.python_version }}
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: ${{ matrix.python_version }}
+    # - name: Set up Python ${{ matrix.python_version }}
+    #   uses: actions/setup-python@v4
+    #   with:
+    #     python-version: ${{ matrix.python_version }}
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          submodules: 'true'
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: 'true'
 
-      - name: Restore cached build artifacts
-        id: cache-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            build/
-            ~/.ccache/
-          key: duckdb-v${{ matrix.duckdb_version }}-${{ matrix.arch }}
+    - name: Restore cached build artifacts
+      id: cache-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          build/
+          ~/.ccache/
+        key: duckdb-v${{ matrix.duckdb_version }}-${{ matrix.arch }}
         
-      - name: Checkout DuckDB to version
-        if: ${{ matrix.duckdb_version != '<submodule_version>'}}
-        run: |
-          cd duckdb
-          git checkout ${{ matrix.duckdb_version }}
+    - name: Checkout DuckDB to version
+      if: ${{ matrix.duckdb_version != '<submodule_version>'}}
+      run: |
+        cd duckdb
+        git checkout ${{ matrix.duckdb_version }}
 
-      - if: ${{ matrix.arch == 'linux_amd64_gcc4' }}
-        uses: ./.github/actions/centos_7_setup
-        with:
-          openssl: 0
+    - if: ${{ matrix.arch == 'linux_amd64_gcc4' }}
+      uses: ./.github/actions/centos_7_setup
+      with:
+        openssl: 0
 
-      - if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
-        uses: ./.github/actions/ubuntu_16_setup
-        with:
-          aarch64_cross_compile: ${{ matrix.arch == 'linux_arm64' && 1 }}
+    - if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
+      uses: ./.github/actions/ubuntu_16_setup
+      with:
+        aarch64_cross_compile: ${{ matrix.arch == 'linux_arm64' && 1 }}
+
+    - name: Tell me about your python install
+      # Debugging step, comment to re-enable
+      if: 0 == 1
+      run: |
+        ls -ld /usr/include/python*
+        which python || echo "No 'python' executable"
+        which python3 || echo "No 'python3' executable"
+        python -V || echo "No 'python' executable"
+        python3 -V || echo "No 'python3' executable"
+        ls -l /usr/include/python3.9/*.h
       
       # Build extension
-      - name: Build extension
-        env:
-          GEN: ninja
-          STATIC_LIBCPP: 1
-          CC: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}
-          CXX: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}
-        run: |
-          make release
+    - name: Build extension
+      env:
+        GEN: ninja
+        STATIC_LIBCPP: 1
+        CC: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}
+        CXX: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}
+      run: |
+        make release
 
-      - name: Cache build artifacts
-        id: cache-save
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            build/
-            ~/.ccache/
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+    - name: Cache build artifacts
+      id: cache-save
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          build/
+          ~/.ccache/
+        key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
-      - name: Run Tests
-        if: ${{ matrix.duckdb_version != 'v0.7.1' }}
-        run: |
-          make test
+    - name: Run Tests
+      if: ${{ matrix.duckdb_version != 'v0.7.1' }}
+      run: |
+        make test
 
-      - name: Run Legacy Tests
-        if: ${{ matrix.duckdb_version == 'v0.7.1' }}
-        run: |
-          make test-legacy
+    - name: Run Legacy Tests
+      if: ${{ matrix.duckdb_version == 'v0.7.1' }}
+      run: |
+        make test-legacy
 
-      - name: Code Format Check
-        run: |
-          make check-format
+    - name: Code Format Check
+      run: |
+        make check-format
 
-      - name: Build / Test Python Libraries
-        run: |
-          make python-ci
+    - name: Build / Test Python Libraries
+      run: |
+        make python-ci
 
-      - name: Run Integration Tests
-        run: |
-          make extension-integration-tests
+    - name: Run Integration Tests
+      run: |
+        make extension-integration-tests
         
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ddb${{ env.DDB_VERSION }}-py${{ matrix.python_version }}-extension-${{ matrix.arch }}
-          path: |
-            build/release/extension/duckdb_udf/*.duckdb_extension
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ddb${{ env.DDB_VERSION }}-py${{ matrix.python_version }}-extension-${{ matrix.arch }}
+        path: |
+          build/release/extension/duckdb_udf/*.duckdb_extension
 
-      - uses: actions/upload-artifact@v2
-        with:
-          # This is a source only package so we are being a bit more descriptive than is really necessary,
-          # but I'm not sure what will happen if the matrix build were to upload multiple artifacts w/the
-          # same name.
-          name: ducktables-py${{ matrix.python_version }}-${{ matrix.arch }}-ddb${{ env.DDB_VERSION }}
-          # todo: this will fail the next time we upgrade the python package version because it's
-          # hardcoded below.
-          path: |
-            pythonpkgs/ducktables/dist/ducktables-0.1.1-py3-none-any.whl
+    - uses: actions/upload-artifact@v2
+      with:
+        # This is a source only package so we are being a bit more descriptive than is really necessary,
+        # but I'm not sure what will happen if the matrix build were to upload multiple artifacts w/the
+        # same name.
+        name: ducktables-py${{ matrix.python_version }}-${{ matrix.arch }}-ddb${{ env.DDB_VERSION }}
+        # todo: this will fail the next time we upgrade the python package version because it's
+        # hardcoded below.
+        path: |
+          pythonpkgs/ducktables/dist/ducktables-0.1.1-py3-none-any.whl
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        if: github.ref == 'refs/heads/main'
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
-          prerelease: true
-          title: "Automatic Build"
-          files: |
-            build/release/extension/python_udf/python_udf.duckdb_extension
+    - uses: "marvinpinto/action-automatic-releases@latest"
+      if: github.ref == 'refs/heads/main'
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "Automatic Build"
+        files: |
+          build/release/extension/python_udf/python_udf.duckdb_extension
 
-      - name: Deploy
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
-          BUCKET_NAME: ${{ secrets.S3_BUCKET }}
-        run: |
-          git config --global --add safe.directory '*'
-          cd duckdb
-          git fetch --tags
-          export DUCKDB_VERSION=`git tag --points-at HEAD`
-          export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
-          cd ..
-          if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
-            echo 'No key set, skipping'
-          elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
-            echo "Uploading release tagged $GITHUB_REF";
-            python3 -m pip install pip awscli
-            ./scripts/extension-upload.sh python_udf ${{ github.ref_name }} $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME true python${{ matrix.python_version }}
-          elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
-            echo "Uploading tip of main branch $GITHUB_REF";
-            python3 -m pip install pip awscli
-            ./scripts/extension-upload.sh python_udf `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME false python${{ matrix.python_version }}
-          else
-            echo "Build is for non tag on a branch other than main, skipping"
-          fi
+    - name: Deploy
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
+        BUCKET_NAME: ${{ secrets.S3_BUCKET }}
+      run: |
+        git config --global --add safe.directory '*'
+        cd duckdb
+        git fetch --tags
+        export DUCKDB_VERSION=`git tag --points-at HEAD`
+        export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+        cd ..
+        if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
+          echo 'No key set, skipping'
+        elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
+          echo "Uploading release tagged $GITHUB_REF";
+          python3 -m pip install pip awscli
+          ./scripts/extension-upload.sh python_udf ${{ github.ref_name }} $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME true python${{ matrix.python_version }}
+        elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
+          echo "Uploading tip of main branch $GITHUB_REF";
+          python3 -m pip install pip awscli
+          ./scripts/extension-upload.sh python_udf `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME false python${{ matrix.python_version }}
+        else
+          echo "Build is for non tag on a branch other than main, skipping"
+        fi

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -44,8 +44,8 @@ jobs:
 
     - name: Setup Python ${{ matrix.python_version }}
       run: |
-        apt-get install -y -qq python${{ python_version }}-dev
-        
+        apt-get install -y -qq python${{ matrix.python_version }}-dev
+  
     # - name: Set up Python ${{ matrix.python_version }}
     #   uses: actions/setup-python@v4
     #   with:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -17,7 +17,7 @@ jobs:
         # Add commits/tags to build against other DuckDB versions
         duckdb_version: ['<submodule_version>']
         # python_version: ['3.8', '3.9', '3.10', '3.11']
-        python_version: ['3.9']
+        python_version: ['3.8', '3.9']
         # arch: ['linux_amd64', 'linux_arm64', 'linux_amd64_gcc4']
         arch: ['linux_amd64']
         include:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -2,7 +2,7 @@ name: Linux
 on: [push]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: yes
 defaults:
   run:
     shell: bash

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -31,7 +31,7 @@ jobs:
           #   container: 'quay.io/pypa/manylinux2014_x86_64'
     env:
       GEN: ninja
-    steps:      
+    steps:
     - name: Extract + Export DuckDB Pinned Version if in Use
       if: '<submodule_version>' == matrix.duckdb_version
       run: |

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -31,170 +31,163 @@ jobs:
           #   container: 'quay.io/pypa/manylinux2014_x86_64'
     env:
       GEN: ninja
-    steps:
-    - name: Extract + Export DuckDB Pinned Version if in Use
-      if: '<submodule_version>' == matrix.duckdb_version
-      run: |
-        export DUCKDB_VERSION=`git tag --points-at HEAD`
-        export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
-        echo "DDB_VERSION=${DUCKDB_VERSION}" >> $GITHUB_ENV
+    steps:      
+      # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
+      # repo is pinned to". That doesn't help when we're building an artifact name that includes
+      # the version of duckdb we've pinned against. So we create a separate variable here that will
+      # contain the actual version number.
+      - name: Extract + Export DuckDB Pinned Version if in Use
+        if: '<submodule_version>' == matrix.duckdb_version
+        run: |
+          export DUCKDB_VERSION=`git tag --points-at HEAD`
+          export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+          echo "DDB_VERSION=${DUCKDB_VERSION}" >> $GITHUB_ENV
       
-    - name: Export DuckDB if Ignoring Pinned Version
-      if: '<submodule_version>' != matrix.duckdb_version
-      run: |
-        echo "DDB_VERSION=${{matrix.duckdb_version}}" >> $GITHUB_ENV
+      - name: Export DuckDB if Ignoring Pinned Version
+        if: '<submodule_version>' != matrix.duckdb_version
+        run: |
+          echo "DDB_VERSION=${{matrix.duckdb_version}}" >> $GITHUB_ENV
 
-    - name: Install required ubuntu packages
-      if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
-      run: |
-        apt-get update -y -qq
-        apt-get install -y -qq software-properties-common
-        add-apt-repository ppa:deadsnakes/ppa
-        apt-get update -y -qq
-        apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client git clang-format libasan6 ccache docker.io
-        git config --global --add safe.directory '*'
+      - name: Install required ubuntu packages
+        if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
+        run: |
+          apt-get update -y -qq
+          apt-get install -y -qq software-properties-common
+          add-apt-repository ppa:deadsnakes/ppa
+          apt-get update -y -qq
+          apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client git clang-format libasan6 ccache docker.io
+          git config --global --add safe.directory '*'
 
-    - name: Setup Python ${{ matrix.python_version }}
-      run: |
-        apt-get install -y -qq python${{ matrix.python_version }}-dev
+      - name: Setup Python ${{ matrix.python_version }}
+        run: |
+          apt-get install -y -qq python${{ matrix.python_version }}-dev
   
-    # - name: Set up Python ${{ matrix.python_version }}
-    #   uses: actions/setup-python@v4
-    #   with:
-    #     python-version: ${{ matrix.python_version }}
+      # - name: Set up Python ${{ matrix.python_version }}
+      #   uses: actions/setup-python@v4
+      #   with:
+      #     python-version: ${{ matrix.python_version }}
 
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        submodules: 'true'
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: 'true'
 
-    - name: Restore cached build artifacts
-      id: cache-restore
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          build/
-          ~/.ccache/
-        key: duckdb-v${{ matrix.duckdb_version }}-${{ matrix.arch }}
+      - name: Restore cached build artifacts
+        id: cache-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            build/
+            ~/.ccache/
+          key: duckdb-v${{ matrix.duckdb_version }}-${{ matrix.arch }}
         
-    - name: Checkout DuckDB to version
-      if: ${{ matrix.duckdb_version != '<submodule_version>'}}
-      run: |
-        cd duckdb
-        git checkout ${{ matrix.duckdb_version }}
+      - name: Checkout DuckDB to version
+        if: ${{ matrix.duckdb_version != '<submodule_version>'}}
+        run: |
+          cd duckdb
+          git checkout ${{ matrix.duckdb_version }}
 
-    - if: ${{ matrix.arch == 'linux_amd64_gcc4' }}
-      uses: ./.github/actions/centos_7_setup
-      with:
-        openssl: 0
+      - if: ${{ matrix.arch == 'linux_amd64_gcc4' }}
+        uses: ./.github/actions/centos_7_setup
+        with:
+          openssl: 0
 
-    - if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
-      uses: ./.github/actions/ubuntu_16_setup
-      with:
-        aarch64_cross_compile: ${{ matrix.arch == 'linux_arm64' && 1 }}
-
-    - name: Tell me about your python install
-      # Debugging step, comment to re-enable
-      if: 0 == 1
-      run: |
-        ls -ld /usr/include/python*
-        which python || echo "No 'python' executable"
-        which python3 || echo "No 'python3' executable"
-        python -V || echo "No 'python' executable"
-        python3 -V || echo "No 'python3' executable"
-        ls -l /usr/include/python3.9/*.h
+      - if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
+        uses: ./.github/actions/ubuntu_16_setup
+        with:
+          aarch64_cross_compile: ${{ matrix.arch == 'linux_arm64' && 1 }}
       
       # Build extension
-    - name: Build extension
-      env:
-        GEN: ninja
-        STATIC_LIBCPP: 1
-        CC: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}
-        CXX: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}
-      run: |
-        make release
+      - name: Build extension
+        env:
+          GEN: ninja
+          STATIC_LIBCPP: 1
+          CC: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-gcc' || '' }}
+          CXX: ${{ matrix.arch == 'linux_arm64' && 'aarch64-linux-gnu-g++' || '' }}
+        run: |
+          make release
 
-    - name: Cache build artifacts
-      id: cache-save
-      uses: actions/cache/save@v3
-      with:
-        path: |
-          build/
-          ~/.ccache/
-        key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+      - name: Cache build artifacts
+        id: cache-save
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            build/
+            ~/.ccache/
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
 
-    - name: Run Tests
-      if: ${{ matrix.duckdb_version != 'v0.7.1' }}
-      run: |
-        make test
+      - name: Run Tests
+        if: ${{ matrix.duckdb_version != 'v0.7.1' }}
+        run: |
+          make test
 
-    - name: Run Legacy Tests
-      if: ${{ matrix.duckdb_version == 'v0.7.1' }}
-      run: |
-        make test-legacy
+      - name: Run Legacy Tests
+        if: ${{ matrix.duckdb_version == 'v0.7.1' }}
+        run: |
+          make test-legacy
 
-    - name: Code Format Check
-      run: |
-        make check-format
+      - name: Code Format Check
+        run: |
+          make check-format
 
-    - name: Build / Test Python Libraries
-      run: |
-        make python-ci
+      - name: Build / Test Python Libraries
+        run: |
+          make python-ci
 
-    - name: Run Integration Tests
-      run: |
-        make extension-integration-tests
+      - name: Run Integration Tests
+        run: |
+          make extension-integration-tests
         
-    - uses: actions/upload-artifact@v2
-      with:
-        name: ddb${{ env.DDB_VERSION }}-py${{ matrix.python_version }}-extension-${{ matrix.arch }}
-        path: |
-          build/release/extension/duckdb_udf/*.duckdb_extension
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ddb${{ env.DDB_VERSION }}-py${{ matrix.python_version }}-extension-${{ matrix.arch }}
+          path: |
+            build/release/extension/duckdb_udf/*.duckdb_extension
 
-    - uses: actions/upload-artifact@v2
-      with:
-        # This is a source only package so we are being a bit more descriptive than is really necessary,
-        # but I'm not sure what will happen if the matrix build were to upload multiple artifacts w/the
-        # same name.
-        name: ducktables-py${{ matrix.python_version }}-${{ matrix.arch }}-ddb${{ env.DDB_VERSION }}
-        # todo: this will fail the next time we upgrade the python package version because it's
-        # hardcoded below.
-        path: |
-          pythonpkgs/ducktables/dist/ducktables-0.1.1-py3-none-any.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          # This is a source only package so we are being a bit more descriptive than is really necessary,
+          # but I'm not sure what will happen if the matrix build were to upload multiple artifacts w/the
+          # same name.
+          name: ducktables-py${{ matrix.python_version }}-${{ matrix.arch }}-ddb${{ env.DDB_VERSION }}
+          # todo: this will fail the next time we upgrade the python package version because it's
+          # hardcoded below.
+          path: |
+            pythonpkgs/ducktables/dist/ducktables-0.1.1-py3-none-any.whl
 
-    - uses: "marvinpinto/action-automatic-releases@latest"
-      if: github.ref == 'refs/heads/main'
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
-        prerelease: true
-        title: "Automatic Build"
-        files: |
-          build/release/extension/python_udf/python_udf.duckdb_extension
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.ref == 'refs/heads/main'
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Automatic Build"
+          files: |
+            build/release/extension/python_udf/python_udf.duckdb_extension
 
-    - name: Deploy
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
-        BUCKET_NAME: ${{ secrets.S3_BUCKET }}
-      run: |
-        git config --global --add safe.directory '*'
-        cd duckdb
-        git fetch --tags
-        export DUCKDB_VERSION=`git tag --points-at HEAD`
-        export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
-        cd ..
-        if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
-          echo 'No key set, skipping'
-        elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
-          echo "Uploading release tagged $GITHUB_REF";
-          python3 -m pip install pip awscli
-          ./scripts/extension-upload.sh python_udf ${{ github.ref_name }} $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME true python${{ matrix.python_version }}
-        elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
-          echo "Uploading tip of main branch $GITHUB_REF";
-          python3 -m pip install pip awscli
-          ./scripts/extension-upload.sh python_udf `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME false python${{ matrix.python_version }}
-        else
-          echo "Build is for non tag on a branch other than main, skipping"
-        fi
+      - name: Deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DEPLOY_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.S3_REGION }}
+          BUCKET_NAME: ${{ secrets.S3_BUCKET }}
+        run: |
+          git config --global --add safe.directory '*'
+          cd duckdb
+          git fetch --tags
+          export DUCKDB_VERSION=`git tag --points-at HEAD`
+          export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
+          cd ..
+          if [[ "$AWS_ACCESS_KEY_ID" == "" ]] ; then
+            echo 'No key set, skipping'
+          elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
+            echo "Uploading release tagged $GITHUB_REF";
+            python3 -m pip install pip awscli
+            ./scripts/extension-upload.sh python_udf ${{ github.ref_name }} $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME true python${{ matrix.python_version }}
+          elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
+            echo "Uploading tip of main branch $GITHUB_REF";
+            python3 -m pip install pip awscli
+            ./scripts/extension-upload.sh python_udf `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME false python${{ matrix.python_version }}
+          else
+            echo "Build is for non tag on a branch other than main, skipping"
+          fi

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -2,7 +2,7 @@ name: Linux
 on: [push]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
-  cancel-in-progress: yes
+  cancel-in-progress: false
 defaults:
   run:
     shell: bash

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -8,8 +8,8 @@ defaults:
     shell: bash
 
 jobs:
-  linux:
-    name: Linux Release
+  linux-build:
+    name: Linux Build
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     strategy:
@@ -31,7 +31,14 @@ jobs:
           #   container: 'quay.io/pypa/manylinux2014_x86_64'
     env:
       GEN: ninja
-
+      DEFAULT_DDB_VERSION: '0.8.0'
+      # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
+      # repo is pinned to". That doesn't help when we're building an artifact name that includes
+      # the version of duckdb we've pinned against. So we create a separate variable here that will
+      # contain the actual version number. Note it requires the pinned version in the repo to match
+      # the above version number. Sorry future me who will def forget to do so.
+      DDB_VERSION: ${{ if '<submodule_version>' == matrix.duckdb_version env.DEFAULT_DDB_VERSION  else  matrix.duckdb_version endif }}
+      
     steps:
     - name: Install required ubuntu packages
       if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}
@@ -136,9 +143,20 @@ jobs:
         
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{matrix.arch}}-extensions
+        name: ddb${{ env.DDB_VERSION }}-py${{ matrix.python_version }}-extension-${{ matrix.arch }}
         path: |
-          build/release/extension/python_udf/python_udf.duckdb_extension
+          build/release/extension/duckdb_udf/*.duckdb_extension
+
+    - uses: actions/upload-artifact@v2
+      with:
+        # This is a source only package so we are being a bit more descriptive than is really necessary,
+        # but I'm not sure what will happen if the matrix build were to upload multiple artifacts w/the
+        # same name.
+        name: ducktables-py${{ matrix.python_version }}-${{ matrix.arch }}-ddb${{ env.DDB_VERSION }}
+        # todo: this will fail the next time we upgrade the python package version because it's
+        # hardcoded below.
+        path: |
+          pythonpkgs/ducktables/dist/ducktables-0.1.1-py3-none-any.whl
 
     - uses: "marvinpinto/action-automatic-releases@latest"
       if: github.ref == 'refs/heads/main'
@@ -149,7 +167,7 @@ jobs:
         title: "Automatic Build"
         files: |
           build/release/extension/python_udf/python_udf.duckdb_extension
-          
+
     - name: Deploy
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_DEPLOY_ID }}
@@ -168,11 +186,11 @@ jobs:
         elif [[ "$GITHUB_REF" =~ ^(refs/tags/v.+)$ ]] ; then
           echo "Uploading release tagged $GITHUB_REF";
           python3 -m pip install pip awscli
-          ./scripts/extension-upload.sh python_udf ${{ github.ref_name }} $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME true
+          ./scripts/extension-upload.sh python_udf ${{ github.ref_name }} $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME true python${{ matrix.python_version }}
         elif [[ "$GITHUB_REF" =~ ^(refs/heads/main)$ ]] ; then
           echo "Uploading tip of main branch $GITHUB_REF";
           python3 -m pip install pip awscli
-          ./scripts/extension-upload.sh python_udf `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME false
+          ./scripts/extension-upload.sh python_udf `git log -1 --format=%h` $DUCKDB_VERSION ${{matrix.arch}} $BUCKET_NAME false python${{ matrix.python_version }}
         else
           echo "Build is for non tag on a branch other than main, skipping"
         fi

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -32,15 +32,19 @@ jobs:
     env:
       GEN: ninja
     steps:
+      # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
+      # repo is pinned to". That doesn't help when we're building an artifact name that includes
+      # the version of duckdb we've pinned against. So we create a separate variable here that will
+      # contain the actual version number.
     - name: Extract + Export DuckDB Pinned Version if in Use
-      if: '<submodule_version>' == matrix.duckdb_version
+      if: ${{ '<submodule_version>' == matrix.duckdb_version }}
       run: |
         export DUCKDB_VERSION=`git tag --points-at HEAD`
         export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
         echo "DDB_VERSION=${DUCKDB_VERSION}" >> $GITHUB_ENV
       
     - name: Export DuckDB if Ignoring Pinned Version
-      if: '<submodule_version>' != matrix.duckdb_version
+      if: ${{ '<submodule_version>' != matrix.duckdb_version }}
       run: |
         echo "DDB_VERSION=${{matrix.duckdb_version}}" >> $GITHUB_ENV
 

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         # Add commits/tags to build against other DuckDB versions
         duckdb_version: ['<submodule_version>']
-        python_version: ['3.8', '3.9', '3.10', '3.11']
+        # python_version: ['3.8', '3.9', '3.10', '3.11']
+        python_version: ['3.9']
         # arch: ['linux_amd64', 'linux_arm64', 'linux_amd64_gcc4']
         arch: ['linux_amd64']
         include:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -17,7 +17,7 @@ jobs:
         # Add commits/tags to build against other DuckDB versions
         duckdb_version: ['<submodule_version>']
         # python_version: ['3.8', '3.9', '3.10', '3.11']
-        python_version: ['3.8', '3.9']
+        python_version: ['3.8', '3.9', '3.10']
         # arch: ['linux_amd64', 'linux_arm64', 'linux_amd64_gcc4']
         arch: ['linux_amd64']
         include:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -17,7 +17,7 @@ jobs:
         # Add commits/tags to build against other DuckDB versions
         duckdb_version: ['<submodule_version>']
         # python_version: ['3.8', '3.9', '3.10', '3.11']
-        python_version: ['3.8', '3.9', '3.10']
+        python_version: ['3.8', '3.9']
         # arch: ['linux_amd64', 'linux_arm64', 'linux_amd64_gcc4']
         arch: ['linux_amd64']
         include:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -32,10 +32,6 @@ jobs:
     env:
       GEN: ninja
     steps:      
-      # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
-      # repo is pinned to". That doesn't help when we're building an artifact name that includes
-      # the version of duckdb we've pinned against. So we create a separate variable here that will
-      # contain the actual version number.
     - name: Extract + Export DuckDB Pinned Version if in Use
       if: '<submodule_version>' == matrix.duckdb_version
       run: |

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # Add commits/tags to build against other DuckDB versions
         duckdb_version: ['<submodule_version>']
-        python_version: ['3.9']
+        python_version: ['3.8', '3.9', '3.10', '3.11']
         # arch: ['linux_amd64', 'linux_arm64', 'linux_amd64_gcc4']
         arch: ['linux_amd64']
         include:
@@ -37,11 +37,15 @@ jobs:
       run: |
         apt-get update -y -qq
         apt-get install -y -qq software-properties-common
-        add-apt-repository ppa:git-core/ppa
+        add-apt-repository ppa:deadsnakes/ppa
         apt-get update -y -qq
         apt-get install -y -qq ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client git clang-format libasan6 ccache docker.io
         git config --global --add safe.directory '*'
 
+    - name: Setup Python ${{ matrix.python_version }}
+      run: |
+        apt-get install -y -qq python${{ python_version }}-dev
+        
     # - name: Set up Python ${{ matrix.python_version }}
     #   uses: actions/setup-python@v4
     #   with:

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -32,10 +32,10 @@ jobs:
     env:
       GEN: ninja
     steps:      
-    # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
-    # repo is pinned to". That doesn't help when we're building an artifact name that includes
-    # the version of duckdb we've pinned against. So we create a separate variable here that will
-    # contain the actual version number.
+      # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
+      # repo is pinned to". That doesn't help when we're building an artifact name that includes
+      # the version of duckdb we've pinned against. So we create a separate variable here that will
+      # contain the actual version number.
     - name: Extract + Export DuckDB Pinned Version if in Use
       if: '<submodule_version>' == matrix.duckdb_version
       run: |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Note these are not inherent limitations that can not be overcome, but presently 
 * Binaries only available for Linux x64 architecture. Builds for OSX and Windows coming soon.
 * Scalar functions only support returning `VARCHAR` values at this time.
 * Not all DuckDB and Python datatypes have been fully mapped. Please file an issue if you find one unsupported.
+* Builds only available for Python 3.8 and Python 3.9 at this time.
 
 # Installation and Usage
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Please see the table below for a further breakdown of each of the named argument
 | columns        | Required. A struct mapping column names to expected DuckDB data types.|
 | kwargs         | Optional. A struct mapping named arguments to be passed to the python function. In python, this is passed as if you called `func(**kwargs)`. |
 
+## Writing Python Functions for Use as Tables
+Python functions can accept an arbitrary number of primitive data which can be invoked in a positional manner.
+
+These functions must return an iterator (or use the 'yield' syntax). Each value in this iterator will represent
+a single row in the database table. As such, the number of values in each row must be consistent across all rows,
+and it must match the number of columns specified when the function is invoked from SQL. Additionally, the data
+type for each value should be convertable to the column data type specified. If the conversion is not possible a
+null value will be substituted.
+    
+
 # Scalar Functions
 The `pycall` scalar function lets you call a Python function and capture its output in the SELECT portion of a SQL query. 
 
@@ -136,44 +146,20 @@ Note these are not inherent limitations that can not be overcome, but presently 
 
 # Installation and Usage
 
-First, [install DuckDB](https://duckdb.org/docs/installation/) v0.8.0 or above.
+First, [install DuckDB](https://duckdb.org/docs/installation/) v0.8.0 or above. Determine the major/minor version of python you'll be using, for instance Python 3.10. In this case you would use `3.10` where PYTHON_VERSION is referenced below.
 
-Next, start the DuckDB shell using the 'unsigned' option. Note that depending on your choosen environment (commandline, Python, etc) the manner in which you specify this will vary. A few examples are provided in the next section below.
-
-Run the following commands to install the extension and activate it:
-
-```sql
-SET custom_extension_repository='net.ednit.duckdb-extensions.s3.us-west-2.amazonaws.com/python_udf/latest';
-INSTALL python_udf;
-LOAD python_udf;
-```
-
-## Writing Python Functions for Use as Tables
-Python functions can accept an arbitrary number of primitive data which can be invoked in a positional manner.
-
-These functions must return an iterator (or use the 'yield' syntax). Each value in this iterator will represent
-a single row in the database table. As such, the number of values in each row must be consistent across all rows,
-and it must match the number of columns specified when the function is invoked from SQL. Additionally, the data
-type for each value should be convertable to the column data type specified. If the conversion is not possible a
-null value will be substituted.
-
-
-## Setting the Unsigned Option
-CLI:
+Next, start the DuckDB shell using the 'unsigned' option. 
 ```shell
 duckdb -unsigned
 ```
 
-Python:
-```python
-con = duckdb.connect(':memory:', config={'allow_unsigned_extensions' : 'true'})
-```
+Run the following commands in the DuckDB REPL to install the extension and activate it:
 
-NodeJS:
-```js
-db = new duckdb.Database(':memory:', {"allow_unsigned_extensions": "true"});
+```sql
+SET custom_extension_repository='net.ednit.duckdb-extensions.s3.us-west-2.amazonaws.com/python_udf/latest/python${PYTHON_VERSION}';
+INSTALL python_udf;
+LOAD python_udf;
 ```
-    
 
 # Development
 Clone the repo being sure to use the `recurse-submodules` option:

--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -7,24 +7,25 @@
 # <architecture>        : Architecture target of the extension binary
 # <s3_bucket>           : S3 bucket to upload to
 # <copy_to_latest>      : Set this as the latest version ("true" / "false", default: "false")
+# <python_version>      : Version of Python the extension was built agains
 
 set -e
 
-if [ 6 != $# ]; then
+if [ 7 != $# ]; then
     # Display the usage comments above, dropping other comments and the shebang
     cat $0 |grep '^#'|head -n 8|tail -n 7;
     exit 1;
 fi
-
+PYVERSION="$7";
 ext="build/release/extension/$1/$1.duckdb_extension"
 
 # compress extension binary
 gzip < $ext > "$1.duckdb_extension.gz"
 
 # upload compressed extension binary to S3
-aws s3 cp $1.duckdb_extension.gz s3://$5/$1/$2/$3/$4/$1.duckdb_extension.gz --acl public-read
+aws s3 cp $1.duckdb_extension.gz s3://$5/$1/$2/$PYVERSION/$3/$4/$1.duckdb_extension.gz --acl public-read
 
 if [ "$6" = 'true' ]; then
-  aws s3 cp $1.duckdb_extension.gz s3://$5/$1/latest/$3/$4/$1.duckdb_extension.gz --acl public-read
+  aws s3 cp $1.duckdb_extension.gz s3://$5/$1/latest/$PYVERSION/$3/$4/$1.duckdb_extension.gz --acl public-read
 fi
 # also uplo


### PR DESCRIPTION
This is a second attempt to produce builds for various Python versions. This attempt uses a PPA to pull down Python install as the `setup-python` action had a lot of glibc issues.