### PR TITLE
Ensure CMake Builds Against Desired Version of Python

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -31,6 +31,7 @@ jobs:
           #   container: 'quay.io/pypa/manylinux2014_x86_64'
     env:
       GEN: ninja
+      PYTHON_VERSION: ${{ matrix.python_version }}
     steps:
       # The 'matrix.duckdb_version' variable may contain a flag indicating "use what every the
       # repo is pinned to". That doesn't help when we're building an artifact name that includes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ set(TARGET_NAME python_udf)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 project(${TARGET_NAME})
 
-find_package(Python REQUIRED COMPONENTS Development)
+set(PYTHON_VERSION "3.8" CACHE STRING "Desired Python version")
+find_package(Python ${PYTHON_VERSION} EXACT COMPONENTS Development)
 get_filename_component(PYTHON_LIB_NAME ${Python_LIBRARIES} NAME)
 
 configure_file(src/include/config.h.in config.h @ONLY)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all: release
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJ_DIR := $(dir $(MKFILE_PATH))
+PYTHON_VERSION := $(if $(PYTHON_VERSION),$(PYTHON_VERSION),3.9)
 
 OSX_BUILD_UNIVERSAL_FLAG=
 ifeq (${OSX_BUILD_UNIVERSAL}, 1)
@@ -46,7 +47,7 @@ debug:
 
 release:
 	mkdir -p build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(EXTENSION_FLAGS) ${CLIENT_FLAGS} -DEXTENSION_STATIC_BUILD=1 -DCMAKE_BUILD_TYPE=Release ${BUILD_FLAGS} -S ./duckdb/ -B build/release && \
+	cmake $(GENERATOR) $(FORCE_COLOR) $(EXTENSION_FLAGS) ${CLIENT_FLAGS} -DPYTHON_VERSION=$(PYTHON_VERSION) -DEXTENSION_STATIC_BUILD=1 -DCMAKE_BUILD_TYPE=Release ${BUILD_FLAGS} -S ./duckdb/ -B build/release && \
 	cmake --build build/release --config Release
 
 extension-release:

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ extension-integration-tests:
 	cp pythonpkgs/ducktables/dist/ducktables-0.1.1-py3-none-any.whl test/extension-integration/
 	cp build/release/extension/python_udf/python_udf.duckdb_extension test/extension-integration/
 	cd test/extension-integration/ && \
-	docker build --build-arg EXTENSION_VERSION=0.1.1 --build-arg DUCKDB_VERSION=0.8.0 -t extension-integration-tests . && \
+	docker build --build-arg PYTHON_VERSION=$(PYTHON_VERSION) --build-arg EXTENSION_VERSION=0.1.1 --build-arg DUCKDB_VERSION=0.8.0 -t extension-integration-tests . && \
 	docker run --rm --interactive extension-integration-tests
 
 


### PR DESCRIPTION
Pass in an explicit Python version from the environment, to the Makefile, and finally to CMake.